### PR TITLE
Added mail_login to dependencies

### DIFF
--- a/service_club_install_profile.info.yml
+++ b/service_club_install_profile.info.yml
@@ -42,6 +42,7 @@ dependencies:
   - image
   - quickedit
   - link
+  - mail_login
   - mailsystem
   - menu_link_content
   - menu_ui


### PR DESCRIPTION
This will automatically install the mail_login module so users can login with their emails from the begining of the system.